### PR TITLE
Develop

### DIFF
--- a/adabmDCA/cli.py
+++ b/adabmDCA/cli.py
@@ -8,7 +8,7 @@ def main():
 
     # Check if the first positional argument is provided
     if len(sys.argv) < 2:
-        print("Error: No command provided. Use 'train', 'sample', 'contacts', 'energies', 'reintegrate' or 'DMS'.")
+        print("Error: No command provided. Use 'train', 'sample', 'contacts', 'energies', 'reintegrate', 'DMS' or 'profmark'.")
         sys.exit(1)
 
     # Assign the first positional argument to a variable
@@ -30,8 +30,10 @@ def main():
             SCRIPT = "td_integration.py"
         case "reintegrate":
             SCRIPT = "reintegrate.py"
+        case "profmark":
+            SCRIPT = "profmark.py"
         case _:
-            print(f"Error: Invalid command '{COMMAND}'. Use 'train', 'sample', 'contacts', 'energies', 'reintegrate' or 'DMS'.")
+            print(f"Error: Invalid command '{COMMAND}'. Use 'train', 'sample', 'contacts', 'energies', 'reintegrate', 'DMS' or 'profmark'.")
             sys.exit(1)
 
     # Run the corresponding Python script with the remaining optional arguments

--- a/adabmDCA/cobalt.py
+++ b/adabmDCA/cobalt.py
@@ -1,0 +1,139 @@
+import torch
+from tqdm.autonotebook import trange
+
+@torch.jit.script
+def has_neighbours(seq: torch.Tensor, db: torch.Tensor, threshold: float) -> bool:
+    """
+    Check if a sequence 'seq' has neighbours in the database 'db', that is, sequences
+    that have pairwise sequence identity greater than 'threshold'.
+    """
+    if len(db) == 0:
+        return False
+    else:
+        seqid = (seq == db).float().sum(dim=1) / seq.shape[0]
+        return bool((seqid > threshold).any().item())
+
+
+def split_train_test(
+    headers: list[str],
+    X: torch.Tensor,
+    seqid_th: float,
+    rnd_gen: torch.Generator | None = None,
+) -> tuple[list, torch.Tensor, list, torch.Tensor]:
+    """Splits X into two sets, T and S, such that no sequence in S has more than
+    'seqid_th' fraction of its residues identical to any sequence in T.
+    
+    Args:
+        headers (list[str]): List of sequence headers.
+        X (torch.Tensor): Encoded input MSA.
+        seqid_th (float): Threshold sequence identity.
+        rnd_gen (torch.Generator, optional): Random number generator. Defaults to None.
+
+    Returns:
+        tuple[list, torch.Tensor, list, torch.Tensor]: Training and test sets.
+    """
+    T_mask = torch.tensor([False] * len(X), dtype=torch.bool, device=X.device)
+    S_mask = torch.tensor([False] * len(X), dtype=torch.bool, device=X.device)
+    perm = torch.randperm(len(X), generator=rnd_gen, device=X.device)
+    X = X[perm]
+    for i in trange(len(X), desc="Train/test splitting", leave=False):
+        has_neighbours_in_S = has_neighbours(X[i], X[S_mask], seqid_th)
+        has_neighbours_in_T = has_neighbours(X[i], X[T_mask], seqid_th)
+        if torch.rand(1, generator=rnd_gen, device=X.device).item() < 0.5:
+            if not has_neighbours_in_T:
+                S_mask[i] = True
+            elif not has_neighbours_in_S:
+                T_mask[i] = True
+        else:
+            if not has_neighbours_in_S:
+                T_mask[i] = True
+            elif not has_neighbours_in_T:
+                S_mask[i] = True
+    
+    T_mask = T_mask.cpu().numpy()
+    S_mask = S_mask.cpu().numpy()
+    T_headers = headers[T_mask]
+    T = X[T_mask]
+    S_headers = headers[S_mask]
+    S = X[S_mask]
+    
+    if len(T) > len(S):
+        return T_headers, T, S_headers, S
+    else:
+        return S_headers, S, T_headers, T
+    
+    
+def prune_redundant_sequences(
+    headers: list[str],
+    X: torch.Tensor,
+    seqid_th: float,
+    rnd_gen: torch.Generator | None = None,
+) -> tuple[list, torch.Tensor]:
+    """Prunes sequences from X such that no sequence has more than 'seqid_th' fraction of its residues identical to any other sequence in the set.
+
+    Args:
+        headers (list[str]): List of sequence headers.
+        X (torch.Tensor): Encoded input MSA.
+        seqid_th (float): Threshold sequence identity.
+        rnd_gen (torch.Generator, optional): Random generator. Defaults to None.
+
+    Returns:
+        tuple[list, torch.Tensor]: Pruned sequences.
+    """
+    perm = torch.randperm(len(X), generator=rnd_gen, device=X.device)
+    X = X[perm]
+    U_mask = torch.tensor([False] * len(X), dtype=torch.bool, device=X.device)
+    for i in trange(len(X), desc="Pruning redundant sequences", leave=False):
+        has_neighbours_in_U = has_neighbours(X[i], X[U_mask], seqid_th)
+        if not has_neighbours_in_U:
+            U_mask[i] = True
+    U_mask = U_mask.cpu().numpy()
+    
+    return headers[U_mask], X[U_mask]
+
+
+def run_cobalt(
+    headers: list[str],
+    X: torch.Tensor,
+    t1: float,
+    t2: float,
+    t3: float,
+    max_train: int | None,
+    max_test: int | None,
+    rnd_gen: torch.Generator | None = None,
+) -> tuple[list, torch.Tensor, list, torch.Tensor]:
+    """
+    Runs the Cobalt algorithm to split the input MSA into training and test sets.
+    
+    Args:
+        headers (list[str]): List of sequence headers.
+        X (torch.Tensor): Encoded input MSA.
+        t1 (float): No sequence in S has more than this fraction of its residues identical to any sequence in T.
+        t2 (float): No pair of test sequences has more than this value fractional identity.
+        t3 (float): No pair of training sequences has more than this value fractional identity.
+        max_train (int | None): Maximum number of sequences in the training set.
+        max_test (int | None): Maximum number of sequences in the test set.
+        rnd_gen (torch.Generator, optional): Random number generator. Defaults to None.
+
+    Returns:
+        tuple[list, torch.Tensor, list, torch.Tensor]: Training and test sets.
+    """
+    # Cobalt step 1
+    headers_train, train, headers_test, test = split_train_test(headers, X, t1, rnd_gen)
+    # Cobalt step 2
+    if len(test) > 0:
+        headers_test, test = prune_redundant_sequences(headers_test, test, t2, rnd_gen)
+    # Cobalt step 3
+    if len(train) > 0:
+        headers_train, train = prune_redundant_sequences(headers_train, train, t3, rnd_gen)
+    
+    if max_train is not None and len(train) > max_train:
+        train_ids = torch.randperm(len(train), generator=rnd_gen)[:max_train]
+        headers_train = headers_train[train_ids]
+        train = train[train_ids]
+    if max_test is not None and len(test) > max_test:
+        test_ids = torch.randperm(len(test), generator=rnd_gen)[:max_test]
+        headers_test = headers_test[test_ids]
+        test = test[test_ids]
+        
+    return headers_train, train, headers_test, test

--- a/adabmDCA/fasta.py
+++ b/adabmDCA/fasta.py
@@ -233,7 +233,7 @@ def compute_weights(
     @torch.jit.script
     def get_sequence_weight(s: torch.Tensor, data: torch.Tensor, L: int, th: float):
         seq_id = torch.sum(s == data, dim=1) / L
-        n_clust = torch.sum(seq_id >= th)
+        n_clust = torch.sum(seq_id > th)
         
         return 1.0 / n_clust
 

--- a/adabmDCA/io.py
+++ b/adabmDCA/io.py
@@ -11,6 +11,7 @@ from adabmDCA.fasta import (
     validate_alphabet,
     get_tokens,
 )
+from adabmDCA.utils import get_mask_save
 
 
 def load_chains(
@@ -157,18 +158,21 @@ def load_params(
 def save_params(
     fname: str,
     params: Dict[str, torch.Tensor],
-    mask: torch.Tensor,
     tokens: str,
+    mask: torch.Tensor | None = None,
 ) -> None:
     """Saves the parameters of the model in a file.
 
     Args:
         fname (str): Path to the file where to save the parameters.
         params (Dict[str, torch.Tensor]): Parameters of the model.
-        mask (torch.Tensor): Mask of the coupling matrix that determines which are the non-zero entries.
         tokens (str): "protein", "dna", "rna" or another string with the alphabet to be used.
+        mask (torch.Tensor | None): Mask of the coupling matrix that determines which are the non-zero entries.
+            If None, the lower-triangular part of the coupling matrix is masked. Defaults to None.
     """
     tokens = get_tokens(tokens)
+    if mask is None:
+        mask = get_mask_save(L, q, device="cpu")
     mask = mask.cpu().numpy()
     params = {k : v.cpu().numpy() for k, v in params.items()}
     
@@ -254,7 +258,7 @@ def load_params_oldformat(
 def save_params_oldformat(
     fname: str,
     params: Dict[str, torch.Tensor],
-    mask: torch.Tensor,
+    mask: torch.Tensor | None = None,
 ) -> None:
     """Saves the parameters of the model in a file. Assumes the old DCA format.
 
@@ -262,7 +266,10 @@ def save_params_oldformat(
         fname (str): Path to the file where to save the parameters.
         params (Dict[str, torch.Tensor]): Parameters of the model.
         mask (torch.Tensor): Mask of the coupling matrix that determines which are the non-zero entries.
+            If None, the lower-triangular part of the coupling matrix is masked. Defaults to None.
     """
+    if mask is None:
+        mask = get_mask_save(L, q, device="cpu")
     mask = mask.cpu().numpy()
     params = {k : v.cpu().numpy() for k, v in params.items()}
     

--- a/adabmDCA/parser.py
+++ b/adabmDCA/parser.py
@@ -1,7 +1,7 @@
 import argparse
 from pathlib import Path
 
-def add_args_dca(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_args_dca(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     dca_args = parser.add_argument_group("General DCA arguments")
     dca_args.add_argument("-d", "--data",         type=Path,  required=True,        help="Filename of the dataset to be used for training the model.")
     dca_args.add_argument("-o", "--output",       type=Path,  default='DCA_model',  help="(Defaults to DCA_model). Path to the folder where to save the model.")
@@ -27,7 +27,7 @@ def add_args_dca(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
     return parser
 
 
-def add_args_reweighting(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_args_reweighting(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     weight_args = parser.add_argument_group("Sequence reweighting arguments")
     weight_args.add_argument("-w", "--weights",      type=Path,  default=None,         help="(Defaults to None). Path to the file containing the weights of the sequences. If None, the weights are computed automatically.")
     weight_args.add_argument("--clustering_seqid",   type=float, default=0.8,          help="(Defaults to 0.8). Sequence Identity threshold for clustering. Used only if 'weights' is not provided.")
@@ -36,7 +36,7 @@ def add_args_reweighting(parser : argparse.ArgumentParser) -> argparse.ArgumentP
     return parser
 
 
-def add_args_checkpoint(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_args_checkpoint(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     checkpoint_args = parser.add_argument_group("Checkpoint arguments")
     checkpoint_args.add_argument("--checkpoints",     type=str,   default="linear",     help="(Defaults to 'linear'). Choses the type of checkpoint criterium to be used.", choices=["linear", "acceptance"])
     checkpoint_args.add_argument("--target_acc_rate", type=float, default=0.5,          help="(Defaults to 0.5). Target acceptance rate for deciding when to save the model when the 'acceptance' checkpoint is used.")
@@ -44,7 +44,7 @@ def add_args_checkpoint(parser : argparse.ArgumentParser) -> argparse.ArgumentPa
     return parser
 
 
-def add_args_eaDCA(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_args_eaDCA(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     eadca_args = parser.add_argument_group("eaDCA arguments")
     eadca_args.add_argument("--gsteps",           type=int,   default=10,           help="(Defaults to 10). Number of gradient updates to be performed on a given graph.")
     eadca_args.add_argument("--factivate",        type=float, default=0.001,        help="(Defaults to 0.001). Fraction of inactive couplings to be proposed for activation at each graph update.")
@@ -52,7 +52,7 @@ def add_args_eaDCA(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
     return parser
 
 
-def add_args_edDCA(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_args_edDCA(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     eddca_args = parser.add_argument_group("edDCA arguments")
     eddca_args.add_argument("--density",          type=float, default=0.02,         help="(Defaults to 0.02). Target density to be reached.")
     eddca_args.add_argument("--drate",            type=float, default=0.01,         help="(Defaults to 0.01). Fraction of remaining couplings to be pruned at each decimation step.")
@@ -60,7 +60,7 @@ def add_args_edDCA(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
     return parser
 
 
-def add_args_train(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_args_train(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser = add_args_dca(parser)
     parser = add_args_eaDCA(parser)
     parser = add_args_edDCA(parser)
@@ -70,7 +70,7 @@ def add_args_train(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
     return parser
 
 
-def add_args_energies(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_args_energies(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument("-d", "--data",         type=Path,   required=True,      help="Path to the fasta file containing the sequences.")
     parser.add_argument("-p", "--path_params",  type=Path,   required=True,      help="Path to the file containing the parameters of DCA model.")
     parser.add_argument("-o", "--output",       type=Path,   required=True,      help="Path to the folder where to save the output.")
@@ -81,7 +81,7 @@ def add_args_energies(parser : argparse.ArgumentParser) -> argparse.ArgumentPars
     return parser
 
 
-def add_args_contacts(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_args_contacts(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument("-p", "--path_params",  type=Path,   required=True,          help="Path to the file containing the parameters of DCA model to sample from.")
     parser.add_argument("-o", "--output",       type=Path,   required=True,          help="Path to the folder where to save the output.")
     parser.add_argument("-l", "--label",        type=str,    default=None,           help="(Defaults to None). If provoded, adds a label to the output files inside the output folder.")
@@ -92,7 +92,7 @@ def add_args_contacts(parser : argparse.ArgumentParser) -> argparse.ArgumentPars
     return parser
 
 
-def add_args_dms(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_args_dms(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument("-d", "--data",         type=Path,   required=True,      
                         help="Path to the fasta file containing wild type sequence. If more than one sequence is present, the first one is used.")
     parser.add_argument("-p", "--path_params",  type=Path,   required=True,      help="Path to the file containing the parameters of DCA model to sample from.")
@@ -104,7 +104,7 @@ def add_args_dms(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
     return parser
 
 
-def add_args_sample(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_args_sample(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument("-p", "--path_params",  type=Path,   required=True,      help="Path to the file containing the parameters of DCA model to sample from.")
     parser.add_argument("-d", "--data",         type=Path,   required=True,      help="Path to the file containing the data to sample from.")
     parser.add_argument("-o", "--output",       type=Path,   required=True,      help="Path to the folder where to save the output.")
@@ -126,7 +126,7 @@ def add_args_sample(parser : argparse.ArgumentParser) -> argparse.ArgumentParser
     
     return parser
 
-def add_args_tdint(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_args_tdint(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument("-p", "--path_params",      type=Path,   required=True,           help="Path to the file containing the parameters of DCA model to sample from.")
     parser.add_argument("-d", "--data",             type=Path,   required=True,           help="Path to the file containing the data to sample from.")
     parser.add_argument("-t", "--path_targetseq",   type=Path,   required=True,           help="Path to the file containing the target sequence.")
@@ -152,9 +152,24 @@ def add_args_tdint(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
     
     return parser
 
-def add_args_reintegration(parser : argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_args_reintegration(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument("--reint",  type=Path,   required=True,  help="Path to the fasta file containing the reintegrated sequences.")
     parser.add_argument("--adj",    type=Path,   required=True,  help="Path to the file containing the adjustment vector.")
     parser.add_argument("--lambda_", type=float,    required=True,  help="Lambda parameter for the reintegration.")
+
+    return parser
+
+def add_args_profmark(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    parser.add_argument("output_prefix", type=str, help="Prefix for the output files.")
+    parser.add_argument("input_msa", type=str, help="Fasta file containing the multiple sequence alignment.")
+    parser.add_argument("-t1", type=float, default=0.5, help="No sequence in S (the candidate training set) has more than this fraction of its residues identical to any sequence in T (the candidate test set). Default is 0.5.")
+    parser.add_argument("-t2", type=float, default=0.5, help="No pair of test sequences has more than this value fractional identity. Default is 0.5.")
+    parser.add_argument("-t3", type=float, default=1.0, help="No pair of training sequences has more than this value fractional identity. Default is 1.0.")
+    parser.add_argument("--bestof", type=int, default=1, help="Runs the algorithm n times and returns the one that maximizes |S| * |T|. Default is 1.")
+    parser.add_argument("--maxtrain", type=int, default=None, help="Maximum number of sequences in the training set.")
+    parser.add_argument("--maxtest", type=int, default=None, help="Maximum number of sequences in the test set.")
+    parser.add_argument("--alphabet", type=str, default="protein", help="Alphabet to use for encoding the sequences. Choose among 'protein', 'rna', 'dna' or a user-defined alphabet. Default is 'protein'.")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducibility. Default is 42.")
+    parser.add_argument("--device", type=str, default="cuda", help="Device to use for computation. Default is 'cuda'.")
 
     return parser

--- a/adabmDCA/scripts/profmark.py
+++ b/adabmDCA/scripts/profmark.py
@@ -1,0 +1,87 @@
+import argparse
+import logging
+import os
+import torch
+from adabmDCA.fasta import import_from_fasta, get_tokens, write_fasta
+from adabmDCA.cobalt import run_cobalt
+from adabmDCA.parser import add_args_profmark
+
+# import command-line input arguments
+def create_parser():
+    parser = argparse.ArgumentParser(description="Splits a multi-sequence alignment FASTA file into training and test sets using the Cobalt algorithm described in Petti et al (2022).")
+    parser = add_args_profmark(parser)
+    
+    return parser
+
+def main(args):
+    print("\n" + "".join(["*"] * 10) + f" Splitting dataset into train and test sets " + "".join(["*"] * 10) + "\n")
+    logging.basicConfig(level=logging.INFO)
+    
+    # Set the device
+    if args.device == "cuda" and not torch.cuda.is_available():
+        args.device = "cpu"
+    device = torch.device(args.device)
+    logging.info(f"Using device: {device}")
+    
+    # check if the output directory exists
+    if not os.path.exists(os.path.dirname(args.output_prefix)):
+        os.makedirs(os.path.dirname(args.output_prefix))
+    # check if the input MSA exists
+    if not os.path.exists(args.input_msa):
+        raise FileNotFoundError(f"Input MSA file {args.input_msa} does not exist.")
+    
+    # load the MSA
+    logging.info(f"Loading MSA from {args.input_msa}")
+    tokens = get_tokens(args.alphabet)
+    headers, msa = import_from_fasta(args.input_msa, tokens)
+    msa = torch.tensor(msa, device=device)
+    logging.info(f"Loaded {len(headers)} sequences of length {len(msa[0])} from {args.input_msa}")
+    
+    # run the Cobalt algorithm
+    geom_mean = 0
+    rnd_gen = torch.Generator(device=device).manual_seed(args.seed)
+    for i in range(args.bestof):
+        logging.info(f"Running Cobalt algorithm iteration {i+1}/{args.bestof}")
+        headers_train_prop, train_prop, headers_test_prop, test_prop = run_cobalt(
+            headers,
+            msa,
+            args.t1,
+            args.t2,
+            args.t3,
+            args.maxtrain,
+            args.maxtest,
+            rnd_gen,
+        )
+        geom_mean_prop = len(train_prop) * len(test_prop)
+        logging.info(f"---> Iteration {i+1}: len(train)={len(train_prop)}, len(test)={len(test_prop)}")
+        if geom_mean_prop > geom_mean:
+            geom_mean = geom_mean_prop
+            headers_train, train, headers_test, test = (
+                headers_train_prop,
+                train_prop,
+                headers_test_prop,
+                test_prop,
+            )
+    if geom_mean == 0:
+        logging.warning("FAILED: No split was found for t1={}, t2={}, t3={}".format(args.t1, args.t2, args.t3))
+        return
+    logging.info(f"Best iteration: len(train)={len(train)}, len(test)={len(test)}, geom_mean={geom_mean}")
+    # write the training and test sets to files
+    write_fasta(
+        os.path.join(args.output_prefix + ".train.fasta"),
+        headers_train,
+        train.cpu().numpy(),
+        tokens,
+    )
+    write_fasta(
+        os.path.join(args.output_prefix + ".test.fasta"),
+        headers_test,
+        test.cpu().numpy(),
+        tokens,
+    )
+    logging.info(f"Training and test sets written in {os.path.dirname(args.output_prefix)}")
+    
+if __name__ == "__main__":
+    parser = create_parser()
+    args = parser.parse_args()
+    main(args)

--- a/adabmDCA/scripts/train.py
+++ b/adabmDCA/scripts/train.py
@@ -2,11 +2,10 @@ from pathlib import Path
 import importlib
 import argparse
 import numpy as np
-
 import torch
 
 from adabmDCA.dataset import DatasetDCA
-from adabmDCA.fasta import get_tokens, import_from_fasta
+from adabmDCA.fasta import get_tokens
 from adabmDCA.io import load_chains, load_params
 from adabmDCA.stats import get_freq_single_point, get_freq_two_points
 from adabmDCA.utils import init_chains, init_parameters, get_device, get_dtype

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='adabmDCA',
-    version='0.4.1',
+    version='0.4.2',
     author='Lorenzo Rosset, Roberto Netti, Anna Paola Muntoni, Francesco Zamponi, Martin Weigt',
     maintainer='Lorenzo Rosset',
     author_email='rosset.lorenzo@gmail.com',


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across multiple files in the `adabmDCA` project, including the addition of new functionality, refactoring of existing methods, and improvements to the codebase. The most significant changes involve the implementation of the Cobalt algorithm for splitting datasets, the addition of new utility functions, and updates to command-line interfaces.

### Critical fixes:
* **Removed the centred version of the gradient**: For some datasets it was breaking the convergence

### New functionality:
* **Cobalt algorithm implementation**: Added the `run_cobalt` function in `adabmDCA/cobalt.py` to split datasets into training and test sets based on sequence identity thresholds. Supporting functions `split_train_test` and `prune_redundant_sequences` were also introduced.
* **New script for dataset splitting**: Added `adabmDCA/scripts/profmark.py` to provide a command-line interface for splitting multi-sequence alignment datasets using the Cobalt algorithm.

### Command-line interface updates:
* **New CLI command**: Added the `profmark` command in `adabmDCA/cli.py` to integrate the new dataset splitting functionality. Updated error messages to reflect the new command. [[1]](diffhunk://#diff-76601bd23efb0fa960b87f9b99f1f5571861b855f0ab181c93d2cf2e55d2df91L11-R11) [[2]](diffhunk://#diff-76601bd23efb0fa960b87f9b99f1f5571861b855f0ab181c93d2cf2e55d2df91R33-R36)
* **Argument parser for `profmark`**: Added `add_args_profmark` in `adabmDCA/parser.py` to define arguments for the new `profmark` command.

### Code improvements and fixes:
* **Modified checkpoint class: now the log file is updated at each gradient update
* **Improved multinomial sampling**: Added `multinomial_one_hot` in `adabmDCA/functional.py` to simplify multinomial sampling logic. Updated `_gibbs_sweep` and `_metropolis_sweep` in `adabmDCA/sampling.py` to use this function. [[1]](diffhunk://#diff-0fd74e968deb6f892e5d048df117756759b3dbec83a97b8465501b6f6126d598R38-R52) [[2]](diffhunk://#diff-a1c87e4b7ba2dba1a8edefb8c00db392d89b3667040d343cb0fcae064b6257c1L33-R32) [[3]](diffhunk://#diff-a1c87e4b7ba2dba1a8edefb8c00db392d89b3667040d343cb0fcae064b6257c1R83-R101)
* **Flexible mask handling in parameter saving**: Updated `save_params` and `save_params_oldformat` in `adabmDCA/io.py` to accept `None` for the mask parameter, defaulting to a lower-triangular mask. [[1]](diffhunk://#diff-6f46612a5b73d99bd6270d77097d5b81a1995699f17a272af9fa434a470735adL160-R175) [[2]](diffhunk://#diff-6f46612a5b73d99bd6270d77097d5b81a1995699f17a272af9fa434a470735adL257-R272)